### PR TITLE
feat: Prompt user for model architecture if missing

### DIFF
--- a/src/api/abstractions.rs
+++ b/src/api/abstractions.rs
@@ -544,7 +544,8 @@ impl BoundingBoxTrait for XYWH {
 #[derive(Deserialize, Clone, Debug, new)]
 pub struct AI {
     pub task: String,
-    pub architecture: String, // yolo, efficientnet, whatever else
+    #[serde(default)]
+    pub architecture: Option<String>, // yolo, efficientnet, whatever else
     pub post_processing: Vec<String>,
     pub classes: Vec<String>,
     #[serde(skip)]

--- a/src/api/inference.rs
+++ b/src/api/inference.rs
@@ -8,6 +8,7 @@ use crate::api::models::Model;
 use crate::api::processing::post_processing::PostProcessing;
 use crate::api::processing::pre_processing::slice_image;
 use crate::api::{import::import_model};
+use eframe::Result;
 use image::{ImageBuffer, Rgb};
 use std::collections::HashMap;
 use std::sync::{OnceLock, RwLock};
@@ -35,7 +36,7 @@ pub fn clear_current_ai2_simple() {
     *guard = None;
 }
 
-pub fn set_model(value: &String, ep: &EP) {
+pub fn set_model(value: &String, ep: &EP) -> Result<(), String> {
     let (model_metadata, data): (AI, Vec<u8>) = import_bq(value).unwrap();
     let session = import_model(&data, ep);
     let post: Vec<PostProcessing> = model_metadata
@@ -52,15 +53,16 @@ pub fn set_model(value: &String, ep: &EP) {
         post,
         session,
         model_metadata.architecture,
-    );
+    )?;
     if CURRENT_AI.get().is_some() {
         *CURRENT_AI.get().unwrap().write().unwrap() = aimodel;
     } else {
         let _ = CURRENT_AI.set(RwLock::new(aimodel));
     }
+    Ok(())
 }
 
-pub fn set_model2(value: &String, ep: &EP) {
+pub fn set_model2(value: &String, ep: &EP) -> Result<(), String> {
     let (model_metadata, data): (AI, Vec<u8>) = import_bq(value).unwrap();
     let session = import_model(&data, ep);
     let post: Vec<PostProcessing> = model_metadata
@@ -78,13 +80,14 @@ pub fn set_model2(value: &String, ep: &EP) {
         post,
         session,
         model_metadata.architecture,
-    );
+    )?;
 
     if CURRENT_AI2.get().is_some() {
         *CURRENT_AI2.get().unwrap().write().unwrap() = Some(aimodel);
     } else {
         let _ = CURRENT_AI2.set(RwLock::new(Some(aimodel)));
     }
+    Ok(())
 }
 
 #[inline(always)]

--- a/src/api/inference.rs
+++ b/src/api/inference.rs
@@ -27,7 +27,7 @@ pub fn init_geofence_data() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-static CURRENT_AI: OnceLock<RwLock<Model>> = OnceLock::new();
+pub static CURRENT_AI: OnceLock<RwLock<Model>> = OnceLock::new();
 static CURRENT_AI2: OnceLock<RwLock<Option<Model>>> = OnceLock::new();
 
 pub fn clear_current_ai2_simple() {

--- a/src/api/models/mod.rs
+++ b/src/api/models/mod.rs
@@ -50,29 +50,33 @@ impl Model {
         task: Task,
         post_processing: Vec<PostProcessing>,
         session: Session,
-        architecture: String,
-    ) -> Self {
-        match architecture.to_lowercase().as_str() {
-            "yolo" => Model::Yolo(Yolo::new(
+        architecture: Option<String>,
+    ) -> Result<Self, String> {
+        let arch = architecture.as_ref().map(|s| s.to_lowercase());
+        match arch.as_deref() {
+            Some("yolo") => Ok(Model::Yolo(Yolo::new(
                 classes,
                 confidence_threshold,
                 nms_threshold,
                 task,
                 post_processing,
                 session,
-            )),
-            "efficientnetv2" => {
-                Model::EfficientNetV2(EfficientNetV2::new(
+            ))),
+            Some("efficientnetv2") => {
+                Ok(Model::EfficientNetV2(EfficientNetV2::new(
                     classes,
                     confidence_threshold, 
                     nms_threshold,
                     task,
                     post_processing,
                     session,
-                ))
+                )))
             }
-            _ => {
-                panic!("Unsupported model architecture: {}", architecture);
+            Some(arch) => {
+                Err(format!("Unsupported model architecture: {}", arch))
+            }
+            None => {
+                Err("No architecture specified".to_string())
             }
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,7 +136,7 @@ pub fn print_ais_table(ais: &Vec<AI>) {
     let arch_width = cmp::max(
         12,
         ais.iter()
-            .map(|ai| ai.architecture.len())
+            .map(|ai| ai.architecture.as_ref().map_or(0, |s| s.len()))
             .max()
             .unwrap_or(0),
     );
@@ -186,7 +186,7 @@ pub fn print_ais_table(ais: &Vec<AI>) {
             "│ {:width1$} │ {:width2$} │ {:width3$} │ {:>width4$} │",
             ai.name,
             ai.task,
-            ai.architecture,
+            ai.architecture.as_deref().unwrap_or(""),
             classes_count,
             width1 = name_width,
             width2 = task_width,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,7 +66,7 @@ pub async fn run_cli(command: Commands) {
                     );
                 }
 
-                set_model2(&model_cls_path, &LIST_EPS[1]);
+                let _ = set_model2(&model_cls_path, &LIST_EPS[1]);
             }
 
             let port = args.port;
@@ -80,7 +80,7 @@ pub async fn run_cli(command: Commands) {
                 );
             }
 
-            set_model(&model_path, &LIST_EPS[1]);
+            let _ = set_model(&model_path, &LIST_EPS[1]);
 
             let ip_text = format!("http://{}:8791", get_ipv4_address().unwrap());
             println!("{}", ASCII_ART);

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -349,7 +349,7 @@ impl Gui {
             });
 
             if (self.ai_selected != previous_ai) && (self.ai_selected.is_some()) {
-                set_model(
+                let _ = set_model(
                     &self.ais[self.ai_selected.unwrap()].get_path(),
                     &LIST_EPS[self.ep_selected],
                 );
@@ -395,7 +395,7 @@ impl Gui {
             });
 
             if (self.ai_cls_selected != previous_ai) && (self.ai_cls_selected.is_some()) {
-                set_model2(
+                let _ = set_model2(
                     &self.ais_cls_only[self.ai_cls_selected.unwrap()].get_path(),
                     &LIST_EPS[self.ep_selected],
                 );
@@ -433,7 +433,7 @@ impl Gui {
                         self.ep_selected = temp_ep_selected;
 
                         if let Some(ai_index) = self.ai_selected {
-                            set_model(&self.ais[ai_index].get_path(), &LIST_EPS[self.ep_selected]);
+                            let _ = set_model(&self.ais[ai_index].get_path(), &LIST_EPS[self.ep_selected]);
                         }
                     } else {
                         self.process_error();
@@ -443,7 +443,7 @@ impl Gui {
                     self.ep_selected = temp_ep_selected;
 
                     if let Some(ai_index) = self.ai_selected {
-                        set_model(&self.ais[ai_index].get_path(), &LIST_EPS[self.ep_selected]);
+                        let _ = set_model(&self.ais[ai_index].get_path(), &LIST_EPS[self.ep_selected]);
                     }
                 }
             }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,9 +1,12 @@
 use super::localization::*;
 use crate::api::abstractions::*;
-use crate::api::bq::get_bqs;
+use crate::api::bq::{get_bqs, import_bq};
 use crate::api::eps::{get_ep_version, LIST_EPS};
 use crate::api::export::write_pred_img_to_file;
 use crate::api::inference::*;
+use std::sync::RwLock;
+use crate::api::models::{Model, Task};
+use crate::api::processing::post_processing::PostProcessing;
 use crate::api::render::{draw_aioutput, draw_no_predictions};
 use crate::api::rest::{
     check_boquila_hub_api, detect_bbox_from_buf_remotely, get_ipv4_address,
@@ -54,6 +57,9 @@ pub struct Gui {
     api_server_url: Option<String>,
     temp_str: String,
     temp_api_str: String,
+    temp_architecture: String,
+    pending_model_path: Option<String>,
+    pending_model_ep: Option<usize>,
     api_result_receiver: Option<std::sync::mpsc::Receiver<bool>>,
     image_processing_receiver: Option<tokio::sync::mpsc::UnboundedReceiver<(usize, AIOutputs)>>,
     feed_processing_receiver:
@@ -92,6 +98,7 @@ pub struct Gui {
     show_export_dialog: bool,
     show_feed_url_dialog: bool,
     show_api_server_dialog: bool,
+    show_architecture_dialog: bool,
     img_state: State,
     video_state: State,
     feed_state: State,
@@ -157,6 +164,9 @@ impl Gui {
             api_result_receiver: None,
             temp_str: "".to_owned(),
             temp_api_str: "".to_owned(),
+            temp_architecture: "yolo".to_owned(),
+            pending_model_path: None,
+            pending_model_ep: None,
             image_processing_receiver: None,
             feed_processing_receiver: None,
             video_processing_receiver: None,
@@ -182,6 +192,7 @@ impl Gui {
             show_export_dialog: false,
             show_feed_url_dialog: false,
             show_api_server_dialog: false,
+            show_architecture_dialog: false,
             mode: Mode::Image,
             img_state: State::init(),
             video_state: State::init(),
@@ -302,6 +313,7 @@ impl Gui {
             }
 
             self.input_api_url_dialog(ctx);
+            self.architecture_selection_dialog(ctx);
         }
     }
 
@@ -349,10 +361,19 @@ impl Gui {
             });
 
             if (self.ai_selected != previous_ai) && (self.ai_selected.is_some()) {
-                let _ = set_model(
-                    &self.ais[self.ai_selected.unwrap()].get_path(),
-                    &LIST_EPS[self.ep_selected],
-                );
+                let model_path = self.ais[self.ai_selected.unwrap()].get_path();
+                match set_model(&model_path, &LIST_EPS[self.ep_selected]) {
+                    Ok(_) => {}
+                    Err(error) => {
+                        if error.contains("No architecture specified") {
+                            self.pending_model_path = Some(model_path);
+                            self.pending_model_ep = Some(self.ep_selected);
+                            self.show_architecture_dialog = true;
+                        } else {
+                            self.process_error();
+                        }
+                    }
+                }
             }
 
             ui.add_space(8.0);
@@ -393,12 +414,20 @@ impl Gui {
                     }
                 }
             });
-
             if (self.ai_cls_selected != previous_ai) && (self.ai_cls_selected.is_some()) {
-                let _ = set_model2(
-                    &self.ais_cls_only[self.ai_cls_selected.unwrap()].get_path(),
-                    &LIST_EPS[self.ep_selected],
-                );
+                let model_path = self.ais_cls_only[self.ai_cls_selected.unwrap()].get_path();
+                match set_model2(&model_path, &LIST_EPS[self.ep_selected]) {
+                    Ok(_) => {}
+                    Err(error) => {
+                        if error.contains("No architecture specified") {
+                            self.pending_model_path = Some(model_path);
+                            self.pending_model_ep = Some(self.ep_selected);
+                            self.show_architecture_dialog = true;
+                        } else {
+                            self.process_error();
+                        }
+                    }
+                }
             }
             ui.add_space(8.0);
         }
@@ -646,6 +675,85 @@ impl Gui {
         }
     }
 
+    pub fn architecture_selection_dialog(&mut self, ctx: &egui::Context) {
+        if self.show_architecture_dialog {
+            egui::Window::new(self.t(Key::select_architecture))
+                .collapsible(false)
+                .resizable(false)
+                .show(ctx, |ui| {
+                    ui.label(self.t(Key::model_have_no_architecture));
+                    ui.add_space(8.0);
+                    
+                    egui::ComboBox::from_id_salt(self.t(Key::select_architecture))
+                        .selected_text(&self.temp_architecture)
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(&mut self.temp_architecture, "yolo".to_string(), "YOLO");
+                            ui.selectable_value(&mut self.temp_architecture, "efficientnetv2".to_string(), "EfficientNetV2");
+                        });
+                    
+                    ui.add_space(8.0);
+                    ui.horizontal(|ui| {
+                        if ui.button("OK").clicked() {
+                            if let (Some(model_path), Some(ep_index)) = (&self.pending_model_path, &self.pending_model_ep) {
+                                // Load model with selected architecture
+                                let (model_metadata, data) = match import_bq(model_path) {
+                                    Ok(result) => result,
+                                    Err(_) => {
+                                        self.process_error();
+                                        self.show_architecture_dialog = false;
+                                        self.pending_model_path = None;
+                                        self.pending_model_ep = None;
+                                        return;
+                                    }
+                                };
+                                let mut updated_metadata = model_metadata;
+                                updated_metadata.architecture = Some(self.temp_architecture.clone());
+                                
+                                // Create model
+                                let session = import_model(&data, &LIST_EPS[*ep_index]);
+                                let post: Vec<PostProcessing> = updated_metadata
+                                    .post_processing
+                                    .iter()
+                                    .map(|s| PostProcessing::from(s.as_str()))
+                                    .filter(|t| !matches!(t, PostProcessing::None))
+                                    .collect();
+                                
+                                match Model::new(
+                                    updated_metadata.classes,
+                                    0.45,
+                                    0.5,
+                                    Task::from(updated_metadata.task.as_str()),
+                                    post,
+                                    session,
+                                    updated_metadata.architecture,
+                                ) {
+                                    Ok(aimodel) => {
+                                        if CURRENT_AI.get().is_some() {
+                                            *CURRENT_AI.get().unwrap().write().unwrap() = aimodel;
+                                        } else {
+                                            let _ = CURRENT_AI.set(RwLock::new(aimodel));
+                                        }
+                                    }
+                                    Err(_) => {
+                                        self.process_error();
+                                    }
+                                }
+                            }
+                            
+                            self.show_architecture_dialog = false;
+                            self.pending_model_path = None;
+                            self.pending_model_ep = None;
+                        }
+                        ui.add_space(8.0);
+                        if ui.button("Cancel").clicked() {
+                            self.show_architecture_dialog = false;
+                            self.pending_model_path = None;
+                            self.pending_model_ep = None;
+                        }
+                    });
+                });
+        }
+    }
     pub fn img_analysis_widget(&mut self, ctx: &egui::Context, ui: &mut egui::Ui) {
         if self.selected_files.len() >= 1 && (self.ai_selected.is_some() || self.is_remote()) {
             ui.vertical_centered(|ui| {

--- a/src/localization.rs
+++ b/src/localization.rs
@@ -55,6 +55,8 @@ pub enum Key {
     confidence_level,
     overlap_filter,
     region_filter,
+    select_architecture,
+    model_have_no_architecture,
 }
 
 pub fn translate(key: Key, lang: &Lang) -> &'static str {
@@ -68,6 +70,12 @@ pub fn translate(key: Key, lang: &Lang) -> &'static str {
             Lang::JA => "AIを選択",
             Lang::PT => "Selecionar uma IA",
         },
+        Key::select_architecture => match lang {
+            _ => "Select model architecture",
+        },
+        Key::model_have_no_architecture => match lang {
+            _ => "This model doesn't have an architecture specified. Please select the appropriate architecture:",
+        }
         Key::confidence_level => match lang {
             Lang::EN => "Confidence",
             Lang::ES => "Confianza",


### PR DESCRIPTION
When loading model downloaded from https://boquila.org/hub
```
thread 'main' panicked at src/api/bq.rs:98:29:
Failed to deserialize JSON into AImodel
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
```
Where the error is
```
error: missing field architecture at line 13 column 3
```

I haven’t checked the model side yet, but here’s a quick workaround: if a model is missing the architecture field (for whatever reason), we prompt users to select one from supported architectures instead of panic.
